### PR TITLE
Add PostInitializationEvent

### DIFF
--- a/src/main/java/com/chrismin13/additionsapi/AdditionsAPI.java
+++ b/src/main/java/com/chrismin13/additionsapi/AdditionsAPI.java
@@ -3,6 +3,7 @@ package com.chrismin13.additionsapi;
 import com.chrismin13.additionsapi.commands.AdditionsCmd;
 import com.chrismin13.additionsapi.commands.AdditionsTab;
 import com.chrismin13.additionsapi.events.AdditionsAPIInitializationEvent;
+import com.chrismin13.additionsapi.events.AdditionsAPIPostInitializationEvent;
 import com.chrismin13.additionsapi.files.ConfigFile;
 import com.chrismin13.additionsapi.files.CustomItemConfig;
 import com.chrismin13.additionsapi.files.DataFile;
@@ -161,6 +162,9 @@ public class AdditionsAPI extends JavaPlugin implements Listener {
         Debug.say("Finished Initialization.");
         Debug.saySuper("aaaaand chat spam too. :P");
 
+        AdditionsAPIPostInitializationEvent postEvent = new AdditionsAPIPostInitializationEvent();
+        instance.getServer().getPluginManager().callEvent(postEvent);
+        
         if (ResourcePackManager.hasResource()) {
             setupHTTPServer();
             if (ResourcePackManager.neededRebuild

--- a/src/main/java/com/chrismin13/additionsapi/events/AdditionsAPIPostInitializationEvent.java
+++ b/src/main/java/com/chrismin13/additionsapi/events/AdditionsAPIPostInitializationEvent.java
@@ -1,0 +1,27 @@
+package com.chrismin13.additionsapi.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+import com.chrismin13.additionsapi.AdditionsAPI;
+import com.chrismin13.additionsapi.items.CustomItem;
+import com.google.common.collect.ImmutableList;
+
+public class AdditionsAPIPostInitializationEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+	
+	public ImmutableList<CustomItem> getCustomItems() {		
+		return AdditionsAPI.getAllCustomItems();
+	}
+	
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+	
+}


### PR DESCRIPTION
This allows one to get the custom item settings immediately after
they're imported from Addons. I needed it for ShinyItems integration for
the Glowstone Sword in RPGAdditions.

https://github.com/MinevoltRPG/RPGAdditions/blob/f1490ad92c6b4ca85b4b147971afb330982cd581/src/main/java/me/drkmatr1984/RPGAdditions/ShinyItemsHook.java#L23
