### PR TITLE
Support for 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,5 +115,13 @@
 			<artifactId>jaxb-api</artifactId>
 			<version>2.3.0</version>
 		</dependency>
+		
+		<!-- This library is included in 1.13, but not in 1.14. -->
+		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.6</version>
+		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Minecraft CraftBukkit 1.14 doesn't have Apache Commons IO. If you include it in the pom.xml file, it will support 1.13 AND 1.14.