### PR TITLE
Fix non-https issue

### DIFF
--- a/src/main/java/us/fihgu/toolbox/resourcepack/ResourcePackListener.java
+++ b/src/main/java/us/fihgu/toolbox/resourcepack/ResourcePackListener.java
@@ -42,6 +42,8 @@ public class ResourcePackListener implements Listener {
 				} else {
 					link = MinePackInitializationMethod.resourcePack;
 				}
+				// nodecraft requires HTTPS, so let's just force theme here so MC will play nice
+				link = link.replace("http:", "https:");
 				if (player != null && player.isOnline())
 					if (ResourcePackManager.hasSendWithHash)
 						try {


### PR DESCRIPTION
Nodecraft will only serve up files over HTTPS. If you navigate via HTTP, most browsers will update you. Given that this flat out won't work unless https is used, may as well just force it here and move along :)